### PR TITLE
Updated function names for restoring

### DIFF
--- a/uetools/UeCase/Case.py
+++ b/uetools/UeCase/Case.py
@@ -233,7 +233,7 @@ class Case(
             self.varinput = self.readyaml(variableyamlpath)  # Read to memory
 
             if self.casefname is not None:
-                self.restore(self.casefname)
+                self.restore_input(self.casefname)
             else:
                 self.reload()
         # Read all data directly from HDF5 file
@@ -780,7 +780,7 @@ class Case(
         # TODO: Can this mess be made somehow prettier?
         if restoresave is True:
             try:
-                self.restoresave(savefname, **kwargs)
+                self.load_state(savefname, **kwargs)
             except:
                 # This can fail if the restore file is not present If
                 # the caller specified a file then they would expect
@@ -912,7 +912,7 @@ class Case(
         if silent is True:
             self.setue("iprint", old_iprint)  # Restore
 
-    def restore(self, inputfname=None, savefname=None, populate=True, **kwargs):
+    def restore_input(self, inputfname=None, savefname=None, populate=True, **kwargs):
         """Restores a full case into memory and object."""
         if self.mutex() is False:
             raise Exception("Case doesn't own UEDGE memory")
@@ -920,3 +920,7 @@ class Case(
         self.setinput(inputfname, savefname=savefname, restoresave=True, **kwargs)
         if populate is True:
             self.populate(silent=True, **kwargs)
+
+    def restore_save(self, savefname, **kwargs):
+        self.load_state(savefname, **kwargs)
+        self.populate(**kwargs)

--- a/uetools/UeCase/Save.py
+++ b/uetools/UeCase/Save.py
@@ -142,7 +142,7 @@ class Save:
             else:
                 self.recursivesave(savefile, self.varinput[group], [group])
 
-    def restoresave(self, savefname=None, **kwargs):
+    def load_state(self, savefname=None, **kwargs):
         """Restores a saved solution
 
         Keyword arguments


### PR DESCRIPTION
Removed closely related names 'restore' and 'restoresave'.
- restore --> restore_input
  - More descriptive name, as this function restores a case from input files
- restoresave --> restore_state
  - More descriptive name, as this function restores the 'state' variables (nis, tes, etc.)
- Added function restore_save
 - Calls restore_state, and also populate UEDGE memory by calling populate