### PR TITLE
Fix NotUniqueError not available error

### DIFF
--- a/src/uetools/UeBayesian/Bayesian.py
+++ b/src/uetools/UeBayesian/Bayesian.py
@@ -27,7 +27,7 @@ from IPython.utils import io
 
 from bayes_opt import BayesianOptimization
 from bayes_opt.acquisition import ExpectedImprovement, UpperConfidenceBound, ProbabilityOfImprovement, ConstantLiar
-from bayes_opt.util import NotUniqueError
+from bayes_opt.exception import NotUniqueError
 
 from sklearn.gaussian_process.kernels import Matern
 from sklearn.gaussian_process import GaussianProcessRegressor


### PR DESCRIPTION
Hi @holm10,

I have modified the file to fix the "NotUniqueError not available". The new version of `bayesian-optimization` has renamed its code, so `NotUniqueError` is not found. BTW, will you consider writing a file to control all versions of the dependent packages in the future?

Yichen